### PR TITLE
Fix astronaut grouping in duration summary

### DIFF
--- a/eva_data_analysis.py
+++ b/eva_data_analysis.py
@@ -145,6 +145,10 @@ def summary_duration_by_astronaut(df) -> pd.DataFrame:
     """
     print('Calculating summary of total EVA time by astronaut')
     subset = df.loc[:, ['crew', 'duration']]
+    subset.crew = subset.crew.str.split(';').apply(
+        lambda x: [i for i in x if i.strip()]
+    )
+    subset = subset.explode('crew')
     subset = add_duration_hours(subset)
     subset = subset.drop('duration', axis=1)
     subset = subset.groupby('crew').sum().reset_index()


### PR DESCRIPTION
## Summary

- Split semicolon-separated crew strings into individual astronaut rows using `explode('crew')` before grouping
- Each astronaut now gets their own total EVA duration across all missions

Fixes #18

## Test plan

- [x] `python eva_data_analysis.py` produces per-astronaut rows (e.g. "Akers", "Al Worden")
- [x] `python -m pytest` passes (8 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)